### PR TITLE
OnValidate can run with unity editor

### DIFF
--- a/Assets/Plugins/HyphenationJpn/Scripts/HyphenationJpn.cs
+++ b/Assets/Plugins/HyphenationJpn/Scripts/HyphenationJpn.cs
@@ -45,11 +45,13 @@ namespace Hyphenation.Jpn
             UpdateText(text);
         }
 
+#if UNITY_EDITOR
         protected override void OnValidate()
         {
             base.OnValidate();
             UpdateText(text);
         }
+#endif
 
         private void UpdateText(string str)
         {

--- a/Assets/Plugins/HyphenationJpn/package.json
+++ b/Assets/Plugins/HyphenationJpn/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.izugch73.hyphenationjpn",
     "displayName": "HyphenationJpn",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "unity": "2022.3",
     "description": "Forked from tsubaki/HyphenationJpn_uGUI",
     "dependencies": {}


### PR DESCRIPTION
This pull request includes changes to the `HyphenationJpn` plugin, focusing on adding editor-specific code and updating the package version.

Changes to add editor-specific code:

* [`Assets/Plugins/HyphenationJpn/Scripts/HyphenationJpn.cs`](diffhunk://#diff-95d9d708e749180b0845dadbf4b9ce2ed46e3c2b2840ac2894d30e9db495454fR48-R54): Wrapped the `OnValidate` method in a `#if UNITY_EDITOR` directive to ensure it only runs in the Unity Editor.

Package version update:

* [`Assets/Plugins/HyphenationJpn/package.json`](diffhunk://#diff-a68b86fe3e45f0a6d23385a4592179eb063d2faf7eba2cafde63d5ce6a27e82aL4-R4): Updated the version from `0.1.0` to `0.1.1`.